### PR TITLE
Parse based on content type

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/prod_run.sh PORT
+web: PORT=$PORT bin/prod_run.sh 

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: mix serve $PORT
+web: bin/prod_run.sh PORT

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: mix serve

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: mix serve
+web: mix serve $PORT

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,0 +1,14 @@
+# Erlang version
+erlang_version=17.5
+
+# Elixir version
+elixir_version=1.0.4
+
+# Always rebuild from scratch on every deploy?
+always_rebuild=true
+
+# Export heroku config vars
+config_vars_to_export=(GITHUB_ACCESS_KEY)
+
+# A command to run right after compiling the app
+post_compile="pwd"

--- a/lib/samuel/api/server.ex
+++ b/lib/samuel/api/server.ex
@@ -12,7 +12,7 @@ defmodule Samuel.API.Server do
   A shell script that starts the server in production mode can be found in
   `bin/prod_run.sh`
   """
-  def start do
+  def start(port \\ 4000) do
     {:ok, _} = Plug.Adapters.Cowboy.http(Samuel.API, [], port: port)
 
     IO.puts """
@@ -33,9 +33,5 @@ defmodule Samuel.API.Server do
     unless iex_running? do
       :timer.sleep :infinity
     end
-  end
-
-  defp port do
-    System.get_env("PORT") || 4000
   end
 end

--- a/lib/samuel/api/server.ex
+++ b/lib/samuel/api/server.ex
@@ -12,7 +12,7 @@ defmodule Samuel.API.Server do
   A shell script that starts the server in production mode can be found in
   `bin/prod_run.sh`
   """
-  def start(port \\ 4000) do
+  def start do
     {:ok, _} = Plug.Adapters.Cowboy.http(Samuel.API, [], port: port)
 
     IO.puts """
@@ -33,5 +33,9 @@ defmodule Samuel.API.Server do
     unless iex_running? do
       :timer.sleep :infinity
     end
+  end
+
+  defp port do
+    System.get_env("PORT") || 4000
   end
 end

--- a/lib/samuel/api/server.ex
+++ b/lib/samuel/api/server.ex
@@ -36,6 +36,13 @@ defmodule Samuel.API.Server do
   end
 
   defp port do
-    System.get_env("PORT") || 4000
+    case System.get_env("PORT") do
+      nil ->
+        4000
+      str ->
+        {port, _} = Integer.parse(str)
+        port
+    end
   end
+
 end

--- a/lib/samuel/data_provider.ex
+++ b/lib/samuel/data_provider.ex
@@ -61,11 +61,22 @@ defmodule Samuel.DataProvider do
   defp get(url, headers \\ %{}, http) do
     headers = Map.merge(default_headers, headers)
     response = http.get!(url, headers)
-    Poison.Parser.parse!(response.body)
+    parse(response.body, response.headers)
+  end
+
+  defp parse(body, %{"Content-Type" => "application/json"}) do
+    Poison.Parser.parse!(body)
+  end
+
+  defp parse(body, _) do
+    body
   end
 
   defp default_headers do
     access_token = Application.get_env(:samuel, :github_access_key)
-    %{ "Authorization" => "token #{access_token}" }
+    %{
+      "Authorization" => "token #{access_token}",
+      "Content-Type" => "application/json"
+    }
   end
 end

--- a/lib/tasks/serve.ex
+++ b/lib/tasks/serve.ex
@@ -2,6 +2,6 @@ defmodule Mix.Tasks.Serve do
   use Mix.Task
 
   def run(port) do
-    Samuel.API.Server.start(Integer.parse port)
+    Samuel.API.Server.start(Integer.parse(port))
   end
 end

--- a/lib/tasks/serve.ex
+++ b/lib/tasks/serve.ex
@@ -1,8 +1,0 @@
-defmodule Mix.Tasks.Serve do
-  use Mix.Task
-
-  def run([port_str]) do
-    {port, _} = Integer.parse(port_str)
-    Samuel.API.Server.start(port)
-  end
-end

--- a/lib/tasks/serve.ex
+++ b/lib/tasks/serve.ex
@@ -1,7 +1,8 @@
 defmodule Mix.Tasks.Serve do
   use Mix.Task
 
-  def run(port) do
-    Samuel.API.Server.start(Integer.parse(port))
+  def run([port_str]) do
+    {port, _} = Integer.parse(port_str)
+    Samuel.API.Server.start(port)
   end
 end

--- a/lib/tasks/serve.ex
+++ b/lib/tasks/serve.ex
@@ -1,0 +1,7 @@
+defmodule Mix.Tasks.Serve do
+  use Mix.Task
+
+  def run(port) do
+    Samuel.API.Server.start(Integer.parse port)
+  end
+end

--- a/test/integration/guidelines_test.exs
+++ b/test/integration/guidelines_test.exs
@@ -7,8 +7,14 @@ defmodule Samuel.Integration.GuidelinesTest do
   with "a pull request is opened" do
     setup context do
       mocks = [
-        get!:  fn(_, _)    -> %{ body: ~s("These are our guidelines.") } end,
-        post!: fn(_, _, _) -> nil end,
+        get!:  fn(_, _)    -> %{
+          body: "These are our guidelines.",
+          headers: %{"Content-Type" => "text/plain"}
+        } end,
+        post!: fn(url, headers, _) ->
+          assert url == "https://api.github.com/repos/reevoo/samuel/issues/1/comments"
+          assert headers["Authorization"] == "token DUMMY-GITHUB-ACCESS-KEY"
+        end,
       ]
       event = %{
         "action" => "opened",
@@ -25,14 +31,7 @@ defmodule Samuel.Integration.GuidelinesTest do
     should "post the guidelines to the pull request", context do
       with_mock HTTPoison, context.mocks do
         API.request(:post, "/hook", context.event)
-
-        x = "{\"body\":\"Guidelines, mofo. Read them.\\n\\n"
-          <> "These are our guidelines.\\n\"}"
-        assert called HTTPoison.post!(
-          "https://api.github.com/repos/reevoo/samuel/issues/1/comments",
-          %{ "Authorization" => "token DUMMY-GITHUB-ACCESS-KEY" },
-          x
-        )
+        # Expectations defined in the mock.
       end
     end
 

--- a/test/integration/has_comments_test.exs
+++ b/test/integration/has_comments_test.exs
@@ -27,7 +27,10 @@ defmodule Samuel.Integration.HasCommentsTest do
 
       setup context do
         Dict.put(context, :mocks, [
-          get!: fn(_, _) -> %{ body: "[]" } end,
+          get!: fn(_, _) -> %{
+            body: "[]",
+            headers: %{"Content-Type" => "application/json"}
+          } end,
           post!: fn(url, headers, _) ->
             assert url == "https://api.github.com/repos/reevoo/samuel/issues/1/comments"
             assert headers["Authorization"] == "token DUMMY-GITHUB-ACCESS-KEY"
@@ -49,7 +52,10 @@ defmodule Samuel.Integration.HasCommentsTest do
       setup context do
         Dict.put(context, :mocks, [
           get!: fn(_, _) ->
-            %{ body: ~s([{"user": {"login": "SOMEONE"}}]) }
+            %{
+              body: ~s([{"user": {"login": "SOMEONE"}}]),
+              headers: %{"Content-Type" => "application/json"}
+            }
           end,
           post!: fn(_, _, _) ->
             assert false # We don't want a POST request!

--- a/test/samuel/data_provider_test.exs
+++ b/test/samuel/data_provider_test.exs
@@ -5,8 +5,11 @@ defmodule Samuel.DataProviderTest do
   doctest Samuel.DataProvider
 
   defmodule HTTPClient do
-    def get!(url, _headers) do
-      %{ body: ~s("DATA-FOR-#{url}") }
+    def get!(url, headers) do
+      %{
+        body: ~s("DATA-FOR-#{url}"),
+        headers: headers
+      }
     end
   end
 


### PR DESCRIPTION
We encountered a Heroku error that it couldn't parse the guidelines. Obviously we don't want it to actually parse the guidelines, so now the JSON parsing is conditional, based on the Content-Type header.