### PR TITLE
Parse based on content type.

### DIFF
--- a/lib/samuel/data_provider.ex
+++ b/lib/samuel/data_provider.ex
@@ -61,11 +61,22 @@ defmodule Samuel.DataProvider do
   defp get(url, headers \\ %{}, http) do
     headers = Map.merge(default_headers, headers)
     response = http.get!(url, headers)
-    Poison.Parser.parse!(response.body)
+    parse(response.body, response.headers)
+  end
+
+  defp parse(body, %{"Content-Type" => "application/json"}) do
+    Poison.Parser.parse!(body)
+  end
+
+  defp parse(body, _) do
+    body
   end
 
   defp default_headers do
     access_token = Application.get_env(:samuel, :github_access_key)
-    %{ "Authorization" => "token #{access_token}" }
+    %{
+      "Authorization" => "token #{access_token}",
+      "Content-Type" => "application/json"
+    }
   end
 end

--- a/test/integration/guidelines_test.exs
+++ b/test/integration/guidelines_test.exs
@@ -7,8 +7,14 @@ defmodule Samuel.Integration.GuidelinesTest do
   with "a pull request is opened" do
     setup context do
       mocks = [
-        get!:  fn(_, _)    -> %{ body: ~s("These are our guidelines.") } end,
-        post!: fn(_, _, _) -> nil end,
+        get!:  fn(_, _)    -> %{
+          body: "These are our guidelines.",
+          headers: %{"Content-Type" => "text/plain"}
+        } end,
+        post!: fn(url, headers, _) ->
+          assert url == "https://api.github.com/repos/reevoo/samuel/issues/1/comments"
+          assert headers["Authorization"] == "token DUMMY-GITHUB-ACCESS-KEY"
+        end,
       ]
       event = %{
         "action" => "opened",
@@ -25,14 +31,7 @@ defmodule Samuel.Integration.GuidelinesTest do
     should "post the guidelines to the pull request", context do
       with_mock HTTPoison, context.mocks do
         API.request(:post, "/hook", context.event)
-
-        x = "{\"body\":\"Guidelines, mofo. Read them.\\n\\n"
-          <> "These are our guidelines.\\n\"}"
-        assert called HTTPoison.post!(
-          "https://api.github.com/repos/reevoo/samuel/issues/1/comments",
-          %{ "Authorization" => "token DUMMY-GITHUB-ACCESS-KEY" },
-          x
-        )
+        # Expectations defined in the mock.
       end
     end
 

--- a/test/integration/has_comments_test.exs
+++ b/test/integration/has_comments_test.exs
@@ -27,7 +27,10 @@ defmodule Samuel.Integration.HasCommentsTest do
 
       setup context do
         Dict.put(context, :mocks, [
-          get!: fn(_, _) -> %{ body: "[]" } end,
+          get!: fn(_, _) -> %{
+            body: "[]",
+            headers: %{"Content-Type" => "application/json"}
+          } end,
           post!: fn(url, headers, _) ->
             assert url == "https://api.github.com/repos/reevoo/samuel/issues/1/comments"
             assert headers["Authorization"] == "token DUMMY-GITHUB-ACCESS-KEY"
@@ -49,7 +52,10 @@ defmodule Samuel.Integration.HasCommentsTest do
       setup context do
         Dict.put(context, :mocks, [
           get!: fn(_, _) ->
-            %{ body: ~s([{"user": {"login": "SOMEONE"}}]) }
+            %{
+              body: ~s([{"user": {"login": "SOMEONE"}}]),
+              headers: %{"Content-Type" => "application/json"}
+            }
           end,
           post!: fn(_, _, _) ->
             assert false # We don't want a POST request!

--- a/test/samuel/data_provider_test.exs
+++ b/test/samuel/data_provider_test.exs
@@ -5,8 +5,11 @@ defmodule Samuel.DataProviderTest do
   doctest Samuel.DataProvider
 
   defmodule HTTPClient do
-    def get!(url, _headers) do
-      %{ body: ~s("DATA-FOR-#{url}") }
+    def get!(url, headers) do
+      %{
+        body: ~s("DATA-FOR-#{url}"),
+        headers: headers
+      }
     end
   end
 


### PR DESCRIPTION
We encountered a Heroku error that it couldn't parse the guidelines. Obviously we don't want it to actually parse the guidelines, so now the JSON parsing is conditional, based on the Content-Type header.