### PR TITLE
Fix readme so it has correct server run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ mix dogma      # Check for style violations
 Run the REPL.
 
 ```sh
-iex -S mix
+bin/prod_run.sh
 ```
 
 You can run the server from the REPL like this:


### PR DESCRIPTION
The change to allow ```mix``` to run test and dogma broke the server run command given in the readme. This corrects this.