### PR TITLE
Moan about old Pull Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Samuel is here to make sure your pull requests are all they can be.
 
 * Post pull request guidelines to your pull request.
 * Moan at you if you merge your pull request without code review.
+* Moan at you if you leave your pull requests open for a long time.
 
 ## What He Will Do In The Future
 
-* Moan at you if you leave your pull requests open for a long time.
 * Moan at you if you commit directly to master.
 
 
@@ -69,6 +69,14 @@ elixir -S mix run -e "Samuel.API.Server.start"
 ```
 
 Code is not automatically reloaded.
+
+## Run the cron jobs
+
+Some checks are done daily. To run them, do this:
+
+```sh
+mix do app.start, daily_checks
+```
 
 ## Deploy it
 

--- a/config/copy_config.exs
+++ b/config/copy_config.exs
@@ -2,9 +2,10 @@ use Mix.Config
 
 config :samuel,
   guidelines_message: """
-  *If you're new, read the [guidelines](https://github.com/reevoo/guidelines/blob/master/pull_requests.md).*
+  *If you're new, read the [guidelines]
+  (https://github.com/reevoo/guidelines/blob/master/pull_requests.md).*
 
-  Good code is **tested**, **designed for change**, **easy to understand** 
+  Good code is **tested**, **designed for change**, **easy to understand**
   and **able to cope when things go wrong**.
 
   Good pull requests are **descriptive**, **small** and **short-lived**.
@@ -20,4 +21,10 @@ config :samuel,
   - [ ] The code is easy to understand.
   - [ ] Tests cover happy and unhappy paths in the code.
   - [ ] Tests are green on CI (or pulled/tested on your machine).
+  """,
+
+  old_pr_message: """
+  Er, hello?
+
+  This Pull Request is too damn old! Merge or close this, sucka.
   """

--- a/config/github_config.exs
+++ b/config/github_config.exs
@@ -5,5 +5,11 @@ github_access_key = case Mix.env do
   otherwise -> System.get_env "GITHUB_ACCESS_KEY"
 end
 
+org_name = case Mix.env do
+  :test     -> "DUMMY-GITHUB-ORG-NAME"
+  otherwise -> System.get_env "GITHUB_ORG_NAME"
+end
+
 config :samuel,
-  github_access_key: github_access_key
+  github_access_key: github_access_key,
+  github_org_name: org_name

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -8,7 +8,4 @@ elixir_version=1.2.3
 always_rebuild=true
 
 # Export heroku config vars
-config_vars_to_export=(GITHUB_ACCESS_KEY)
-
-# A command to run right after compiling the app
-post_compile="pwd"
+config_vars_to_export=(GITHUB_ACCESS_KEY,GITHUB_ORG_NAME)

--- a/lib/mix/tasks/daily_checks.ex
+++ b/lib/mix/tasks/daily_checks.ex
@@ -1,0 +1,18 @@
+defmodule Mix.Tasks.DailyChecks do
+  @moduledoc """
+  Runs daily checks.
+  """
+
+  use Mix.Task
+  alias Samuel.Events
+
+  def run(_args) do
+    Events.respond(tick_event)
+  end
+
+  defp tick_event do
+    %{
+      "action" => "daily"
+    }
+  end
+end

--- a/lib/samuel/action.ex
+++ b/lib/samuel/action.ex
@@ -4,8 +4,7 @@ defmodule Samuel.Action do
   """
 
   defstruct action: nil,
-    repo: nil,
-    pull_id: nil,
+    comments_url: nil,
     message: nil
 
 end

--- a/lib/samuel/api.ex
+++ b/lib/samuel/api.ex
@@ -8,23 +8,17 @@ defmodule Samuel.API do
   See https://developer.github.com/v3/activity/events/types/ for types.
   """
 
-  alias Samuel.Checks
-  alias Samuel.DataProvider
-  alias Samuel.Dispatchers
+  alias Samuel.Events
 
   use Plug.Router
-
   plug Plug.Parsers, parsers: [:json], json_decoder: Poison
   plug :match
   plug :dispatch
 
   post "/hook" do
-    event  = conn.body_params
-    checks = event |> Checks.suitable_checks
-    data   = checks |> DataProvider.resolve_requirements(event)
+    actions = Events.respond(conn.body_params)
 
-    Checks.perform_checks(checks, data)
-    |> Dispatchers.perform_actions!
+    actions
     |> case do
       [] ->
         send_resp(conn, 200, "No actions.")

--- a/lib/samuel/check.ex
+++ b/lib/samuel/check.ex
@@ -15,16 +15,6 @@ defmodule Samuel.Check do
   """
   defcallback check(pull_request_data)  :: none | action
 
-
-  @doc """
-  A function that returns the action that needs to be taken for an event,
-  *presuming that the event fails the check*.
-
-  It should not test to see if it fails or not.
-  """
-  defcallback action(pull_request_data) :: action
-
-
   @doc """
   A function that returns a list of the requirements of the checker that must
   be resolved and added to the `pull_request_data` before `check/1` has

--- a/lib/samuel/checks.ex
+++ b/lib/samuel/checks.ex
@@ -22,7 +22,7 @@ defmodule Samuel.Checks do
   """
   def perform_checks(checks, %{event: _} = data) do
     checks
-    |> Enum.map(fn(module) -> module.check(data) end)
+    |> Enum.flat_map(fn(module) -> module.check(data) end)
   end
 
 
@@ -48,6 +48,12 @@ defmodule Samuel.Checks do
   defp suitable_checks("closed", %{"pull_request" => %{"merged" => true}}) do
     [
       Samuel.Checks.HasComments
+    ]
+  end
+
+  defp suitable_checks("daily", _) do
+    [
+      Samuel.Checks.Old
     ]
   end
 

--- a/lib/samuel/checks/guidelines.ex
+++ b/lib/samuel/checks/guidelines.ex
@@ -13,11 +13,9 @@ defmodule Samuel.Checks.Guidelines do
   end
 
   def action(data) do
-
     %Action{
       action: :post_comment,
-      repo: data.event["repository"]["full_name"],
-      pull_id: data.event["pull_request"]["number"],
+      comments_url: data.event["pull_request"]["comments_url"],
       message: data.guidelines
     }
   end

--- a/lib/samuel/checks/has_comments.ex
+++ b/lib/samuel/checks/has_comments.ex
@@ -19,8 +19,7 @@ defmodule Samuel.Checks.HasComments do
   def action(event) do
     %Action{
       action: :post_comment,
-      repo: event["repository"]["full_name"],
-      pull_id: event["pull_request"]["number"],
+      comments_url: event["pull_request"]["comments_url"],
       message: """
       I don't see any comments on your Pull Request.
 

--- a/lib/samuel/checks/old.ex
+++ b/lib/samuel/checks/old.ex
@@ -1,0 +1,47 @@
+defmodule Samuel.Checks.Old do
+  @moduledoc """
+  Posts if a Pull Request gets too old.
+
+  Only run this once a day! Otherwise, it will hammer your PRs
+  on day 7.
+  """
+
+  @behaviour Samuel.Check
+
+  alias Samuel.Action
+
+  def check(data) do
+    data.open_prs["items"]
+    |> Enum.map(fn(pr) -> check(pr, data) end)
+    |> Enum.reject(fn(action) -> action == nil end)
+  end
+
+  defp check(pr, data) do
+    days = days_since_creation(pr)
+
+    if days != 0 && rem(days, 7) == 0 do
+      action(pr, data)
+    else
+      nil
+    end
+  end
+
+  def action(pr, data) do
+    %Action{
+      action: :post_comment,
+      comments_url: pr["comments_url"],
+      message: data.old_pr_message
+    }
+  end
+
+  def requirements do
+    ~w(open_prs old_pr_message)a
+  end
+
+  defp days_since_creation(pr) do
+    {:ok, creation_date} = Timex.parse(pr["created_at"], "{ISO:Extended:Z}")
+    now = Timex.DateTime.today
+
+    Timex.diff(creation_date, now, :days)
+  end
+end

--- a/lib/samuel/data_provider.ex
+++ b/lib/samuel/data_provider.ex
@@ -65,8 +65,24 @@ defmodule Samuel.DataProvider do
     )
   end
 
+  defp fetch(:open_prs, _, http) do
+    org = Application.get_env(:samuel, :github_org_name)
+    open_prs_url = "https://api.github.com/search/issues" <>
+      "?q=type:pr+state:open+user:#{org}"
+
+    get(
+      open_prs_url,
+      %{"Content-Type" => "application/json"},
+      http
+    )
+  end
+
   defp fetch(:guidelines, _, _) do
     Application.get_env(:samuel, :guidelines_message)
+  end
+
+  defp fetch(:old_pr_message, _, _) do
+    Application.get_env(:samuel, :old_pr_message)
   end
 
   defp get(url, headers, http) do

--- a/lib/samuel/dispatchers/github.ex
+++ b/lib/samuel/dispatchers/github.ex
@@ -9,14 +9,17 @@ defmodule Samuel.Dispatchers.Github do
     Enum.map(actions, &process_action(&1, http))
   end
 
-
   defp process_action(%{action: :post_comment} = action, http) do
-    repo = action.repo
-    pull = action.pull_id
-    json = Poison.encode!(%{ body: action.message })
+    post(
+      action.comments_url,
+      action.message,
+      http
+    )
+  end
 
-    "https://api.github.com/repos/#{repo}/issues/#{pull}/comments"
-    |> http.post!(json, auth_headers)
+  defp post(url, message, http) do
+    json = Poison.encode!(%{ body: message })
+    http.post!(url, json, auth_headers)
   end
 
   defp access_token do

--- a/lib/samuel/events.ex
+++ b/lib/samuel/events.ex
@@ -1,0 +1,18 @@
+defmodule Samuel.Events do
+  @moduledoc """
+  Utilities for responding to events.
+  """
+
+  alias Samuel.Checks
+  alias Samuel.DataProvider
+  alias Samuel.Dispatchers
+
+  def respond(event) do
+    checks = event |> Checks.suitable_checks
+    data   = checks |> DataProvider.resolve_requirements(event)
+
+    checks
+    |> Checks.perform_checks(data)
+    |> Dispatchers.perform_actions!
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Samuel.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [
-      applications: [:logger, :httpoison],
+      applications: [:logger, :httpoison, :tzdata],
       mod: {Samuel, []}
     ]
   end
@@ -36,6 +36,8 @@ defmodule Samuel.Mixfile do
       {:poison, "~> 1.5"},
       # HTTP Client
       {:httpoison, "~> 0.7"},
+      # Timey wimey stuff
+      {:timex, "~> 2.1"},
 
       # BDD test macros
       {:shouldi, "~> 0.3", only: :test},

--- a/test/integration/has_comments_test.exs
+++ b/test/integration/has_comments_test.exs
@@ -11,13 +11,10 @@ defmodule Samuel.Integration.HasCommentsTest do
         "action" => "closed",
         "pull_request" => %{
           "merged" => true,
-          "number" => "1",
           "user" => %{
             "login" => "AUTHOR"
-          }
-        },
-        "repository" => %{
-          "full_name" => "reevoo/samuel",
+          },
+          "comments_url" => "COMMENTS-URL"
         }
       }
       %{ event: event }
@@ -32,8 +29,7 @@ defmodule Samuel.Integration.HasCommentsTest do
             headers: [{"Content-Type", "application/json"}]
           } end,
           post!: fn(url, _, headers) ->
-            assert url == "https://api.github.com/"
-                          <> "repos/reevoo/samuel/issues/1/comments"
+            assert url == "COMMENTS-URL"
             assert headers == [
               {"Authorization", "token DUMMY-GITHUB-ACCESS-KEY"}
             ]

--- a/test/samuel/checks/has_comments_test.exs
+++ b/test/samuel/checks/has_comments_test.exs
@@ -3,18 +3,15 @@ defmodule Samuel.Checks.HasCommentsTest do
 
   alias Samuel.Checks.HasComments
 
-  having "a pull request havingout comments" do
+  having "a pull request without comments" do
     setup data do
       %{
         event: %{
           "action" => "closed",
           "pull_request" => %{
             "merged" => true,
-            "number" => 6
+            "comments_url" => "COMMENTS-URL"
           },
-          "repository" => %{
-            "full_name" => "reevoo/samuel"
-          }
         },
         commit_comments: [],
         pr_comments: [],
@@ -27,29 +24,25 @@ defmodule Samuel.Checks.HasCommentsTest do
       assert action.action == :post_comment
     end
 
-    should "get the repo and pull request ID", data do
+    should "get the comments URL", data do
       action = HasComments.check(data)
 
-      assert action.repo == "reevoo/samuel"
-      assert action.pull_id == 6
+      assert action.comments_url == "COMMENTS-URL"
     end
   end
 
-  having "a pull request having PR comments from Samuel and the author" do
+  having "a pull request with PR comments from Samuel and the author" do
     setup data do
       %{
         event: %{
           "action" => "closed",
           "pull_request" => %{
             "merged" => true,
-            "number" => 6,
             "user" => %{
               "login" => "AUTHOR"
-            }
+            },
+            "comments_url" => "COMMENTS-URL"
           },
-          "repository" => %{
-            "full_name" => "reevoo/samuel"
-          }
         },
         pr_comments: [
           %{ "user" => %{ "login" => "reevoo-samuel" } },
@@ -66,21 +59,18 @@ defmodule Samuel.Checks.HasCommentsTest do
     end
   end
 
-  having "a pull request having PR comments from others" do
+  having "a pull request with PR comments from others" do
     setup data do
       %{
         event: %{
           "action" => "closed",
           "pull_request" => %{
             "merged" => true,
-            "number" => 6,
             "user" => %{
               "login" => "AUTHOR"
-            }
+            },
+            "comments_url" => "COMMENTS-URL"
           },
-          "repository" => %{
-            "full_name" => "reevoo/samuel"
-          }
         },
         pr_comments: [
           %{ "user" => %{ "login" => "SOMEBODY-ELSE" } },
@@ -94,21 +84,18 @@ defmodule Samuel.Checks.HasCommentsTest do
     end
   end
 
-  having "a pull request having commit comments from Samuel and the author" do
+  having "a pull request with commit comments from Samuel and the author" do
     setup data do
       %{
         event: %{
           "action" => "closed",
           "pull_request" => %{
             "merged" => true,
-            "number" => 6,
             "user" => %{
               "login" => "AUTHOR"
-            }
+            },
+            "comments_url" => "COMMENTS-URL"
           },
-          "repository" => %{
-            "full_name" => "reevoo/samuel"
-          }
         },
         commit_comments: [
           %{ "user" => %{ "login" => "reevoo-samuel" } },
@@ -125,21 +112,18 @@ defmodule Samuel.Checks.HasCommentsTest do
     end
   end
 
-  having "a pull request having commit comments from others" do
+  having "a pull request with commit comments from others" do
     setup data do
       %{
         event: %{
           "action" => "closed",
           "pull_request" => %{
             "merged" => true,
-            "number" => 6,
             "user" => %{
               "login" => "AUTHOR"
-            }
+            },
+            "comments_url" => "COMMENTS-URL"
           },
-          "repository" => %{
-            "full_name" => "reevoo/samuel"
-          }
         },
         commit_comments: [
           %{ "user" => %{ "login" => "SOMEBODY-ELSE" } },

--- a/test/samuel/checks/old_test.exs
+++ b/test/samuel/checks/old_test.exs
@@ -1,0 +1,139 @@
+defmodule Samuel.Checks.OldTest do
+  use ShouldI
+  alias Samuel.Checks.Old
+
+  having "a new pull request" do
+    setup data do
+      now = Timex.DateTime.today
+      {:ok, now_string} = now |> Timex.format("{ISO:Extended:Z}")
+
+      %{
+        event: %{
+          "action" => "daily",
+        },
+        open_prs: %{
+          "items" => [
+            %{
+              "created_at" => now_string
+            }
+          ]
+        },
+      }
+    end
+
+    should "not comment", data do
+      action = Old.check(data)
+      assert action == []
+    end
+  end
+
+  having "a new-enough pull request" do
+    setup data do
+      now = Timex.DateTime.today
+      {:ok, new_time} = now
+      |> Timex.shift(days: 1)
+      |> Timex.format("{ISO:Extended:Z}")
+
+      %{
+        event: %{
+          "action" => "daily",
+        },
+        open_prs: %{
+          "items" => [
+            %{
+              "created_at" => new_time
+            }
+          ]
+        }
+      }
+    end
+
+    should "not comment", data do
+      action = Old.check(data)
+      assert action == []
+    end
+  end
+
+  having "a old pull request (on the comment interval)" do
+    setup data do
+      now = Timex.DateTime.today
+      {:ok, new_time} = now
+      |> Timex.shift(days: 7)
+      |> Timex.format("{ISO:Extended:Z}")
+
+      %{
+        event: %{
+          "action" => "daily",
+        },
+        open_prs: %{
+          "items" => [
+            %{
+              "created_at" => new_time
+            }
+          ]
+        },
+        old_pr_message: "OLD-PR-MESSAGE"
+      }
+    end
+
+    should "comment", data do
+      action = Old.check(data)
+      assert action != []
+    end
+  end
+
+  having "a old pull request (after the comment interval)" do
+    setup data do
+      now = Timex.DateTime.today
+      {:ok, new_time} = now
+      |> Timex.shift(days: 8)
+      |> Timex.format("{ISO:Extended:Z}")
+
+      %{
+        event: %{
+          "action" => "daily",
+        },
+        open_prs: %{
+          "items" => [
+            %{
+              "created_at" => new_time
+            }
+          ]
+        }
+      }
+    end
+
+    should "not comment", data do
+      action = Old.check(data)
+      assert action == []
+    end
+  end
+
+  having "a really old pull request (on the comment interval)" do
+    setup data do
+      now = Timex.DateTime.today
+      {:ok, new_time} = now
+      |> Timex.shift(days: 14)
+      |> Timex.format("{ISO:Extended:Z}")
+
+      %{
+        event: %{
+          "action" => "daily",
+        },
+        open_prs: %{
+          "items" => [
+            %{
+              "created_at" => new_time
+            }
+          ]
+        },
+        old_pr_message: "OLD-PR-MESSAGE"
+      }
+    end
+
+    should "comment", data do
+      action = Old.check(data)
+      assert action != []
+    end
+  end
+end

--- a/test/samuel/dispatchers/github_test.exs
+++ b/test/samuel/dispatchers/github_test.exs
@@ -9,14 +9,13 @@ defmodule Samuel.Dispatchers.GithubTest do
     setup context do
       actions = [%Action{
         action: :post_comment,
-        repo: "REPO",
-        pull_id: 123,
+        comments_url: "COMMENTS-URL",
         message: "Hello, world!"
       }]
 
       mock = [
         post!: fn(url, _, headers) ->
-          assert url == "https://api.github.com/repos/REPO/issues/123/comments"
+          assert url == "COMMENTS-URL"
           assert headers == [
             { "Authorization", "token DUMMY-GITHUB-ACCESS-KEY" }
           ]


### PR DESCRIPTION
When `mix do app.start, daily_checks` is run, Samuel will look at all open Pull Requests. If the number of days the PR has been open is divisible by 7 (and isn't 0), Samuel will comment.

This _should_ work with [Heroku Scheduler](https://elements.heroku.com/addons/scheduler).
